### PR TITLE
Prevent reorder of [FireMockProtocol] in UITableView after changes

### DIFF
--- a/FireMock/FireMockManager.swift
+++ b/FireMock/FireMockManager.swift
@@ -11,14 +11,53 @@ import Foundation
 public struct FireMock {
 
 	public struct ConfigMock: Equatable {
+		
+		public enum ConfigMockType: Equatable {
+			case url(url: URL)
+			case regex(regex: String)
+			
+			public static func ==(lhs: ConfigMockType, rhs: ConfigMockType) -> Bool {
+				switch (lhs, rhs) {
+				case (.url(url: let lhsURL), .url(url: let rhsURL)):
+					return lhsURL == rhsURL
+				case (.regex(regex: let lhsRegex), .regex(regex: let rhsRegex)):
+					return lhsRegex == rhsRegex
+				default:
+					return false
+				}
+			}
+			
+			var debugDescription: String {
+				switch self {
+				case .regex(regex: let regex):
+					return regex
+				case .url(url: let url):
+					return "\(url)"
+				}
+			}
+		}
+		
         var mocks: [FireMockProtocol]
         var httpMethod: MockHTTPMethod
         var enabled: Bool = true
-        var url: URL?
-        var regex: String?
+		var mockType: ConfigMockType
+		
+		public init(regex: String, mocks: [FireMockProtocol], httpMethod: MockHTTPMethod, enabled: Bool = true) {
+			self.mocks = mocks
+			self.httpMethod = httpMethod
+			self.enabled = enabled
+			self.mockType = ConfigMockType.regex(regex: regex)
+		}
+		
+		public init(url: URL, mocks: [FireMockProtocol], httpMethod: MockHTTPMethod, enabled: Bool = true) {
+			self.mocks = mocks
+			self.httpMethod = httpMethod
+			self.enabled = enabled
+			self.mockType = ConfigMockType.url(url: url)
+		}
 		
 		public static func ==(lhs: ConfigMock, rhs: ConfigMock) -> Bool {
-			return lhs.httpMethod == rhs.httpMethod && (lhs.url == rhs.url || lhs.regex == rhs.regex)
+			return lhs.httpMethod == rhs.httpMethod && lhs.mockType == rhs.mockType
 		}
     }
 
@@ -47,9 +86,9 @@ public struct FireMock {
         }
 
         // Remove similar mock if existing
-        mocks = mocks.filter({ !($0.url == url && $0.httpMethod == httpMethod) })
+        mocks = mocks.filter({ !($0.mockType == ConfigMock.ConfigMockType.url(url: url) && $0.httpMethod == httpMethod) })
 
-        let config = ConfigMock(mocks: mock, httpMethod: httpMethod, enabled: enabled, url: url, regex: nil)
+        let config = ConfigMock(url: url, mocks: mock, httpMethod: httpMethod, enabled: enabled)
         mocks.append(config)
 
         let names = mock.reduce("", { $0 + " " + ($1.name ?? "") })
@@ -73,9 +112,9 @@ public struct FireMock {
         }
 
         // Remove similar mock if existing
-        mocks = mocks.filter({ !($0.regex == regex && $0.httpMethod == httpMethod) })
+        mocks = mocks.filter({ !($0.mockType == ConfigMock.ConfigMockType.regex(regex: regex) && $0.httpMethod == httpMethod) })
         
-        let config = ConfigMock(mocks: mock, httpMethod: httpMethod, enabled: enabled, url: nil, regex: regex)
+        let config = ConfigMock(regex: regex, mocks: mock, httpMethod: httpMethod, enabled: enabled)
         mocks.append(config)
 
         let names = mock.reduce("", { $0 + " " + ($1.name ?? "") })
@@ -87,7 +126,7 @@ public struct FireMock {
     /// - Parameter url: URL associated to mock.
     ///   - httpMethod: HTTP Method.
     public static func unregister(forURL url: URL, httpMethod: MockHTTPMethod) {
-        mocks = mocks.filter({ !($0.url == url && $0.httpMethod == httpMethod) })
+        mocks = mocks.filter({ !($0.mockType == ConfigMock.ConfigMockType.url(url: url) && $0.httpMethod == httpMethod) })
         FireMockDebug.debug(message: "Unregister mock for \(url)", level: .high)
     }
 
@@ -98,7 +137,7 @@ public struct FireMock {
     ///   - regex: regex associated to mock
     ///   - httpMethod: HTTP Method.
     public static func unregister(regex: String, httpMethod: MockHTTPMethod) {
-        mocks = mocks.filter({ !($0.regex == regex && $0.httpMethod == httpMethod) })
+        mocks = mocks.filter({ !($0.mockType == ConfigMock.ConfigMockType.regex(regex: regex) && $0.httpMethod == httpMethod) })
         FireMockDebug.debug(message: "Unregister mock for regex \(regex)", level: .high)
     }
 
@@ -110,15 +149,16 @@ public struct FireMock {
 
     internal static func update(configMock: ConfigMock) {
 		
-		if let index = mocks.index(of: configMock) {
+		if let index = mocks.index(of: configMock) { // Maintain order of ConfigMocks as they were added
 			mocks = mocks.filter({ $0 != configMock })
 			mocks.insert(configMock, at: index)
 		} else {
+			// This Shouldn't be able to happen but recover anyway
 			mocks.append(configMock)
 		}
 
         let names = configMock.mocks.reduce("", { $0 + " " + ($1.name ?? "") })
-        FireMockDebug.debug(message: "Update mock -\(names)- for \(String(describing: configMock.url))", level: .high)
+        FireMockDebug.debug(message: "Update mock -\(names)- for \(configMock.mockType.debugDescription)", level: .high)
     }
 
     /// Enabled FireMock.

--- a/FireMock/FireMockManager.swift
+++ b/FireMock/FireMockManager.swift
@@ -10,12 +10,16 @@ import Foundation
 
 public struct FireMock {
 
-    public struct ConfigMock {
+	public struct ConfigMock: Equatable {
         var mocks: [FireMockProtocol]
         var httpMethod: MockHTTPMethod
         var enabled: Bool = true
         var url: URL?
         var regex: String?
+		
+		public static func ==(lhs: ConfigMock, rhs: ConfigMock) -> Bool {
+			return lhs.httpMethod == rhs.httpMethod && (lhs.url == rhs.url || lhs.regex == rhs.regex)
+		}
     }
 
     /// Mocks added.
@@ -105,10 +109,13 @@ public struct FireMock {
     }
 
     internal static func update(configMock: ConfigMock) {
-        mocks = mocks.filter({
-            !($0.url == configMock.url && $0.httpMethod == configMock.httpMethod) ||
-                !($0.regex == configMock.regex && $0.httpMethod == configMock.httpMethod) })
-        mocks.append(configMock)
+		
+		if let index = mocks.index(of: configMock) {
+			mocks = mocks.filter({ $0 != configMock })
+			mocks.insert(configMock, at: index)
+		} else {
+			mocks.append(configMock)
+		}
 
         let names = configMock.mocks.reduce("", { $0 + " " + ($1.name ?? "") })
         FireMockDebug.debug(message: "Update mock -\(names)- for \(String(describing: configMock.url))", level: .high)
@@ -181,8 +188,4 @@ public struct FireMock {
         FireMockDebug.level = level
         FireMockDebug.prefix = prefix
     }
-}
-
-func ==(lhs: FireMock.ConfigMock, rhs: FireMock.ConfigMock) -> Bool {
-    return lhs.url == rhs.url && rhs.httpMethod == lhs.httpMethod
 }

--- a/FireMock/FireMockTableViewCell.swift
+++ b/FireMock/FireMockTableViewCell.swift
@@ -26,7 +26,12 @@ class FireMockTableViewCell: UITableViewCell {
     func configure(mock: FireMock.ConfigMock) {
         httpMethod.text = mock.httpMethod.rawValue
         self.name.text = mock.mocks.first?.name ?? "No Name"
-        url.text = mock.url?.absoluteString ?? mock.regex
+		switch mock.mockType {
+		case .url(url: let mockURL):
+			url.text = mockURL.absoluteString
+		case .regex(regex: let regex):
+			url.text = regex
+		}
         parameters.text = parametersNames(mock: mock)
         enabledSwitch.isOn = mock.enabled
 
@@ -48,16 +53,15 @@ class FireMockTableViewCell: UITableViewCell {
             return params.joined(separator: "/")
         }
 
-        if let url = mock.url {
-            let urlComponents = URLComponents(string: url.absoluteString)
-            if let queryItems = urlComponents?.queryItems {
-                return queryItems.map({ $0.name }).joined(separator: "/")
-            }
-        }
-
-        if let _ = mock.regex {
-            return "Regex used"
-        }
+		switch mock.mockType {
+		case .url(url: let url):
+			let urlComponents = URLComponents(string: url.absoluteString)
+			if let queryItems = urlComponents?.queryItems {
+				return queryItems.map({ $0.name }).joined(separator: "/")
+			}
+		case .regex(regex: _):
+			return "Regex used"
+		}
 
         return "0 parameters"
     }

--- a/FireMock/FireMockViewController.swift
+++ b/FireMock/FireMockViewController.swift
@@ -37,7 +37,14 @@ public class FireMockViewController: UIViewController {
 
     private func setupNavBar() {
         self.title = "Mock Registers"
-        let backButtonItem = UIBarButtonItem(title: "Back", style: .done, target: self, action: #selector(FireMockViewController.back(_:)))
+		
+		let buttonTitle: String
+		if self.isModal {
+			buttonTitle = "Done"
+		} else {
+			buttonTitle = "Back"
+		}
+        let backButtonItem = UIBarButtonItem(title: buttonTitle, style: .done, target: self, action: #selector(FireMockViewController.back(_:)))
         backButtonItem.tintColor = .black
 
         self.navigationItem.leftBarButtonItem = backButtonItem
@@ -92,4 +99,20 @@ extension FireMockViewController: UITableViewDataSource, UITableViewDelegate {
             self.navigationController?.pushViewController(mockSelectionController, animated: true)
         }
     }
+}
+
+extension UIViewController {
+	var isModal: Bool {
+		if let index = navigationController?.viewControllers.index(of: self), index > 0 {
+			return false
+		} else if presentingViewController != nil {
+			return true
+		} else if navigationController?.presentingViewController?.presentedViewController == navigationController  {
+			return true
+		} else if tabBarController?.presentingViewController is UITabBarController {
+			return true
+		} else {
+			return false
+		}
+	}
 }

--- a/FireMock/FireURLProtocol.swift
+++ b/FireMock/FireURLProtocol.swift
@@ -115,42 +115,42 @@ public class FireURLProtocol: URLProtocol, URLSessionDataDelegate, URLSessionTas
             guard let mock = configMock.mocks.first else { continue }
 
             let params = mock.parameters ?? []
-            // Case where urls absolute string are equals and parameters name from protocol are equals with query items from url req.
-            if
-                let urlComp = urlComponents,
-                let queryItems = urlComp.queryItems,
-                params.count == queryItems.count,
-                params == queryItems.map({ $0.name }),
-                configMock.url?.absoluteStringWithoutQuery == url.absoluteStringWithoutQuery,
-                configMock.httpMethod.rawValue == httpMethod {
-                return configMock
-            }
-            // Case where zero parameters exists in two url.
-            else if
-                let urlComp = urlComponents,
-                urlComp.queryItems == nil,
-                params.count == 0,
-                configMock.url?.absoluteString == url.absoluteString,
-                configMock.httpMethod.rawValue == httpMethod {
-
-                return configMock
-            }
-            // case : Url req with params, url mock with params but parameters in protocol is empty.
-            else if
-                let urlComp = urlComponents,
-                let _ = urlComp.queryItems,
-                configMock.url == url,
-                configMock.httpMethod.rawValue == httpMethod {
-
-                return configMock
-            }
-            // case : Find if exist with regex.
-            else if
-                let regex = configMock.regex,
-                !(search(regex: regex, in: url.absoluteString).isEmpty),
-                configMock.httpMethod.rawValue == httpMethod {
-                return configMock
-            }
+			switch configMock.mockType {
+			case .url(url: let configMockURL):
+				// Case where urls absolute string are equals and parameters name from protocol are equals with query items from url req.
+				if
+					let urlComp = urlComponents,
+					let queryItems = urlComp.queryItems,
+					params.count == queryItems.count,
+					params == queryItems.map({ $0.name }),
+					configMockURL.absoluteStringWithoutQuery == url.absoluteStringWithoutQuery,
+					configMock.httpMethod.rawValue == httpMethod {
+					return configMock
+				}
+				// Case where zero parameters exists in two url.
+				else if
+					let urlComp = urlComponents,
+					urlComp.queryItems == nil,
+					params.count == 0,
+					configMockURL.absoluteString == url.absoluteString,
+					configMock.httpMethod.rawValue == httpMethod {
+					return configMock
+				}
+				// case : Url req with params, url mock with params but parameters in protocol is empty.
+				else if
+					let urlComp = urlComponents,
+					let _ = urlComp.queryItems,
+					configMockURL == url,
+					configMock.httpMethod.rawValue == httpMethod {
+					return configMock
+				}
+			case .regex(regex: let configMockRegex):
+				// case : Find if exist with regex.
+				if !(search(regex: configMockRegex, in: url.absoluteString).isEmpty),
+				configMock.httpMethod.rawValue == httpMethod {
+					return configMock
+				}
+			}
         }
 
         return nil


### PR DESCRIPTION
Hi, thanks for a great library.  The order of the [FireMockProtocol] in the table was changing every time one of mocks was selected.  I prefer the order to stay in the order originally registered to prevent confusion when you pop back to the table. Also,hopefully, made it a little safer by adding state Enum to ConfigMock for either url or regex.  All your included tests pass ok. 